### PR TITLE
Add query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "vue-resource": "^1.3.4",
     "vue-router": "^2.3.1",
     "vuejs-paginate": "^0.9.1",
-    "vuex": "^2.3.1"
+    "vuex": "^2.3.1",
+    "vuex-router-sync": "^4.3.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",

--- a/src/components/Entreprise.vue
+++ b/src/components/Entreprise.vue
@@ -1,6 +1,14 @@
 <template>
   <div>
-    <router-link to="">Revenir aux résultats</router-link>
+    <router-link :to="{ path: '/search',
+      query: {
+        fullText: this.$store.state.search.storedFullText,
+        page: this.$store.state.search.pageNumber,
+        postalCode: this.$store.state.filters.filterPostalCode,
+        activityCode: this.$store.state.filters.filterActivityCode
+      }}">
+      Revenir aux résultats
+    </router-link>
     <div v-if="result">
       <p>Nom entreprise : {{result.nom_raison_sociale}}</p>
       <ul>

--- a/src/components/Entreprise.vue
+++ b/src/components/Entreprise.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <router-link to=/>Revenir aux résultats</router-link>
+    <router-link to="">Revenir aux résultats</router-link>
     <div v-if="result">
       <p>Nom entreprise : {{result.nom_raison_sociale}}</p>
       <ul>

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -50,10 +50,14 @@ export default {
     'Results': Results
   },
   created: function () {
-    this.$store.commit('setFullText', this.$route.query.fullText)
-    this.$store.commit('setPage', this.$route.query.page)
-    // Add filters commit here later
-    store.dispatch('requestSearch')
+    if (this.$route.query.page) {
+      this.$store.commit('setPage', this.$route.query.page)
+    }
+    // TODO: Add filters commit here later
+    if (this.$route.query.fullText) {
+      this.$store.commit('setFullText', this.$route.query.fullText)
+      store.dispatch('requestSearch')
+    }
   },
   data () {
     return {
@@ -80,12 +84,10 @@ export default {
     }
   },
   watch: {
-    // addQueryParamsToURL () {
-    //   this.$router.push({ path: 'search', query: { optionsToGet: 'test' } })
-    // }
     '$route' (to, from) {
-      console.log('Console logged !')
-      this.$store.dispatch('requestSearch')
+      if (this.$route.query.fullText) {
+        this.$store.dispatch('requestSearch')
+      }
     }
   }
 }

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -39,6 +39,7 @@ import SearchBar from '@/components/search/SearchBar'
 import SearchBarSmall from '@/components/search/SearchBarSmall'
 import SearchCategories from '@/components/search/SearchCategories'
 import Results from '@/components/Results.vue'
+import store from '@/store/index.js'
 
 export default {
   name: 'Search',
@@ -47,6 +48,12 @@ export default {
     'SearchBarSmall': SearchBarSmall,
     'SearchCategories': SearchCategories,
     'Results': Results
+  },
+  created: function () {
+    this.$store.commit('setFullText', this.$route.query.fullText)
+    this.$store.commit('setPage', this.$route.query.page)
+    // Add filters commit here later
+    store.dispatch('requestSearch')
   },
   data () {
     return {
@@ -60,9 +67,6 @@ export default {
       this.$store.commit('clearFilters')
       this.$store.dispatch('executeSearch')
     },
-    requestSearch () {
-      this.$store.dispatch('executeSearch')
-    },
     clearButton () {
       this.$store.commit('clearResults')
     }
@@ -73,6 +77,15 @@ export default {
     },
     showWelcomeText () {
       return this.$store.state.welcomeText.isWelcomeTextVisible
+    }
+  },
+  watch: {
+    // addQueryParamsToURL () {
+    //   this.$router.push({ path: 'search', query: { optionsToGet: 'test' } })
+    // }
+    '$route' (to, from) {
+      console.log('Console logged !')
+      this.$store.dispatch('requestSearch')
     }
   }
 }

--- a/src/components/paginate/PaginateModule.vue
+++ b/src/components/paginate/PaginateModule.vue
@@ -27,7 +27,7 @@ export default {
   methods: {
     selectPage (pageNum) {
       this.$store.state.search.pageNumber = pageNum
-      this.$store.dispatch('executeSearch')
+      this.$store.dispatch('requestSearch')
     }
   }
 }

--- a/src/components/paginate/PaginateModule.vue
+++ b/src/components/paginate/PaginateModule.vue
@@ -1,10 +1,12 @@
 <template>
   <paginate
+    ref="paginate"
     :container-class="'pagination'"
     :page-class = "'pagesButtons'"
     :prev-class="'pagesButtons'"
     :next-class="'pagesButtons'"
     :page-count="totalPageNumber"
+    :initial-page="initialPage"
     :prev-text="'Precédent'"
     :next-text="'Suivant'"
     :click-handler="selectPage">
@@ -19,6 +21,11 @@ Vue.component('paginate', Paginate)
 
 export default {
   name: 'Results',
+  data: function () {
+    return {
+      initialPage: parseInt(this.$store.state.search.pageNumber) - 1
+    }
+  },
   computed: {
     totalPageNumber: function () {
       return parseInt(this.$store.getters.totalPageNumber)

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -21,7 +21,6 @@ export default {
     fullText: function (setFullText) {
       if (String(this.fullText).length >= 3) {
         this.$store.commit('setFullText', this.fullText)
-        // this.$router.push({ name: 'Search', query: {text: this.fullText} })
         this.$store.dispatch('requestSearch')
       } else {
         this.$store.commit('setFullText', '')

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -21,7 +21,8 @@ export default {
     fullText: function (setFullText) {
       if (String(this.fullText).length >= 3) {
         this.$store.commit('setFullText', this.fullText)
-        this.$store.dispatch('executeSearch')
+        // this.$router.push({ name: 'Search', query: {text: this.fullText} })
+        this.$store.dispatch('requestSearch')
       } else {
         this.$store.commit('setFullText', '')
       }

--- a/src/components/search/SearchBarSmall.vue
+++ b/src/components/search/SearchBarSmall.vue
@@ -33,7 +33,7 @@ export default {
     /* eslint-disable no-undef */
     filterSearched: function (setFilterSearched) { // TODO: delete the param ?
       this.$store.commit('setSearchFilters', this.filterSearchPayload)
-      this.$store.dispatch('executeSearch')
+      this.$store.dispatch('requestSearch')
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,9 @@ import App from './App'
 import router from '@/router'
 import store from '@/store/index.js'
 import constants from '@/constants.js'
+import { sync } from 'vuex-router-sync'
+
+sync(store, router)
 
 require('@/style/app.scss')
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,15 +1,23 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import Results from '@/components/Results'
+// import store from '@/store/index.js'
+// import Search from '@/components/Search'
 import Entreprise from '@/components/Entreprise'
 
 Vue.use(Router)
 
 export default new Router({
+  mode: 'history',
   routes: [
     {
-      path: '/',
-      name: 'Results',
+      path: '/search?*',
+      name: 'Search',
+      component: Results
+    },
+    {
+      path: '/search',
+      name: 'SearchEmpty',
       component: Results
     },
     {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,8 +1,6 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import Results from '@/components/Results'
-// import store from '@/store/index.js'
-// import Search from '@/components/Search'
 import Entreprise from '@/components/Entreprise'
 
 Vue.use(Router)

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -1,31 +1,35 @@
 import Vue from 'vue'
 import constants from '@/constants'
 import store from '@/store/index.js'
+import router from '@/router/index.js'
 
 const state = {
   storedFullText: '',
+  pageNumber: 1,
   baseAdress: constants.baseAdress,
-  baseAdressSiret: constants.baseAdressSiret,
-  pageNumber: 1
+  baseAdressSiret: constants.baseAdressSiret
 }
 
 const getters = {
-  pageNumberToGet: state => {
-    return '?page=' + state.pageNumber
-  },
   adressToGet: state => {
-    return state.baseAdress + state.storedFullText + store.getters.optionsToGet
+    return state.baseAdress + store.getters.queryToGet
+  },
+  queryToGet: state => {
+    return store.state.route.query.fullText + store.getters.optionsToGet
+  },
+  pageNumberToGet: state => {
+    return '?page=' + store.state.route.query.page
   },
   optionsToGet: state => {
     return store.getters.pageNumberToGet + store.getters.filtersToGet
   },
   filtersToGet: state => {
     let filters = ''
-    if (store.state.filters.filterPostalCode) {
-      filters = filters + '&code_postal=' + state.filterPostalCode
+    if (store.state.route.query.postalCode) {
+      filters = filters + '&code_postal=' + store.state.route.query.postalCode
     }
-    if (store.state.filters.filterActivityCode) {
-      filters = filters + '&activite_principale=' + state.filterActivityCode
+    if (store.state.route.query.activityCode) {
+      filters = filters + '&activite_principale=' + store.state.route.query.activityCode
     }
     return filters
   }
@@ -46,8 +50,29 @@ const mutations = {
     })
   }
 }
+//
+// const data = {
+//   routeQuery: ''
+// }
+//
+// const watch = {
+//   routeQuery: function () {
+//     store.dispatch('requestSearch')
+//   }
+// }
 
 const actions = {
+  requestSearch () {
+    router.push({ path: 'search',
+      query: {
+        fullText: state.storedFullText,
+        page: state.pageNumber,
+        postalCode: store.state.filters.filterPostalCode,
+        activityCode: store.state.filters.filterActivityCode
+      }
+    })
+    store.dispatch('executeSearch')
+  },
   executeSearch () {
     if (store.getters.infoMessage) {
       return false
@@ -72,4 +97,6 @@ export default {
   getters,
   mutations,
   actions
+  // watch,
+  // data
 }

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -50,16 +50,6 @@ const mutations = {
     })
   }
 }
-//
-// const data = {
-//   routeQuery: ''
-// }
-//
-// const watch = {
-//   routeQuery: function () {
-//     store.dispatch('requestSearch')
-//   }
-// }
 
 const actions = {
   requestSearch () {
@@ -97,6 +87,4 @@ export default {
   getters,
   mutations,
   actions
-  // watch,
-  // data
 }


### PR DESCRIPTION
Pull request for #17 

Had to change the whole frontend logic, searches are now made with query params in the URL.
Store is now synchronized with router, to be able to get the query params and keep the logic centralized in the store.
Searches are now made with requestSearch that sets up the URL query and then call executeSearch.

It is now possible to save searches.

Might need to fix the filters in a next update.