### PR TITLE
Removed result numbers in categories

### DIFF
--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -2,6 +2,7 @@
   <div class="container">
     <div v-if="isSearchNotEmpty">
       <p>{{informationMessage}}</p>
+      <p>Résultats : {{numberResults}}</p>
       <ul>
         <li v-for="result in storedResultsEtablissements">
           <router-link tag="div" :to="{ name: 'Etablissement', params: {siret: result['siret']}}" id="result-box">

--- a/src/components/search/SearchCategories.vue
+++ b/src/components/search/SearchCategories.vue
@@ -3,22 +3,22 @@
     <ul class="results__categories">
       <li v-bind:class="{emphasize_this: emphasizeAll}"
           v-on:click="changeFocus('all')">
-        <p>Tous les résultats ({{numberResultsAll}})</p>
+        <p>Tous les résultats</p>
         <div class="results__white_div"></div>
       </li>
       <li v-bind:class="{emphasize_this: emphasizeEntreprises}"
           v-on:click="changeFocus('entreprises')">
-        <p>Entreprises ({{numberResultsEntreprises}})</p>
+        <p>Entreprises</p>
         <div class="results__white_div"></div>
       </li>
       <li v-bind:class="{emphasize_this: emphasizeEntreprisesIndividuelles}"
           v-on:click="changeFocus('entreprisesIndividuelles')">
-        <p>Entreprises Individuelles ({{numberResultsEntreprisesIndividuelles}})</p>
+        <p>Entreprises Individuelles</p>
         <div class="results__white_div"></div>
       </li>
       <li v-bind:class="{emphasize_this: emphasizeAssociations}"
           v-on:click="changeFocus('associations')">
-        <p>Associations ({{numberResultsAssociations}})</p>
+        <p>Associations</p>
         <div class="results__white_div"></div>
       </li>
     </ul>
@@ -66,18 +66,6 @@ export default {
         myClass = 'hide_this'
       }
       return myClass
-    },
-    numberResultsAll () {
-      return this.$store.state.categories.numberResultsAll
-    },
-    numberResultsEntreprises () {
-      return this.$store.state.categories.numberResultsEntreprises
-    },
-    numberResultsEntreprisesIndividuelles () {
-      return this.$store.state.categories.numberResultsEntreprisesIndividuelles
-    },
-    numberResultsAssociations () {
-      return this.$store.state.categories.numberResultsAssociations
     }
   }
 }

--- a/src/store/modules/categories.js
+++ b/src/store/modules/categories.js
@@ -1,32 +1,12 @@
 import store from '@/store/index.js'
 
 const state = {
-  focusedCategory: 'all',
-  numberResultsAll: 0,
-  numberResultsEntreprises: 0,
-  numberResultsEntreprisesIndividuelles: 0,
-  numberResultsAssociations: 0
+  focusedCategory: 'all'
 }
 
 const mutations = {
   focusCategory (state, category) {
     state.focusedCategory = category
-  },
-  setNumberCategory (state, category) {
-    switch (category.name) {
-      case 'all':
-        state.numberResultsAll = category.value
-        break
-      case 'entreprises':
-        state.numberResultsEntreprises = category.value
-        break
-      case 'entreprisesIndividuelles':
-        state.numberResultsEntreprisesIndividuelles = category.value
-        break
-      case 'associations':
-        state.numberResultsAssociations = category.value
-        break
-    }
   }
 }
 

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -83,7 +83,6 @@ const actions = {
       }
     })
     store.dispatch('executeSearch')
-    store.dispatch('executeNumberSearches')
   },
   executeSearch () {
     if (store.getters.infoMessage) {
@@ -100,20 +99,6 @@ const actions = {
       } else {
         store.commit('setStatus', response.status)
       }
-    })
-  },
-  executeNumberSearches () {
-    const categories =
-      [{name: 'all', query: ''},
-       {name: 'entreprises', query: '&is_entrepreneur_individuel=yes'},
-       {name: 'entreprisesIndividuelles', query: '&is_entrepreneur_individuel=no'},
-       {name: 'associations', query: '&is_ess=O'}]
-    categories.forEach(function (category) {
-      Vue.http.get(store.getters.adressToGetWithoutCategories + category.query).then(response => {
-        store.commit('setNumberCategory', {name: category.name, value: response.body.total_results})
-      }, response => {
-        store.commit('setNumberCategory', {name: category.name, value: 0})
-      })
     })
   }
 }


### PR DESCRIPTION
The feature of showing the number of results in categories is bugged right now & add a lot of requests & will be removed in the next version of the website.

Instead of debugging it, it seems more clever to remove it for now.

Since it is still a useful information, it have been replaced with a counter of results before the result list.